### PR TITLE
Fix incorrect vertex assignment in halfedge parser

### DIFF
--- a/python_lib/halfedge_mesh/halfedge_mesh.py
+++ b/python_lib/halfedge_mesh/halfedge_mesh.py
@@ -141,8 +141,8 @@ class HalfedgeMesh:
                 Edges[all_facet_edges[i]] = Halfedge()
                 Edges[all_facet_edges[i]].facet = facet
                 Edges[all_facet_edges[i]].vertex = vertices[
-                    all_facet_edges[i][0]]###
-                vertices[all_facet_edges[i][0]].halfedge = Edges[all_facet_edges[i]]###
+                    all_facet_edges[i][1]]
+                vertices[all_facet_edges[i][1]].halfedge = Edges[all_facet_edges[i]]
                 halfedge_count +=1
 
             facet.halfedge = Edges[all_facet_edges[0]]


### PR DESCRIPTION
# Fix incorrect vertex assignment in halfedge parser

## Summary

The `.off` parser incorrectly assigns the **source vertex** to `he.vertex` instead of the **destination vertex**.

For an edge `(u, v)`:
- **Was using:** `all_facet_edges[i][0]` → source vertex `u`
- **Should be:** `all_facet_edges[i][1]` → destination vertex `v`

## The Bug

```python
# Line 143-145 (BEFORE)
Edges[...].vertex = vertices[all_facet_edges[i][0]]  # WRONG - source
vertices[all_facet_edges[i][0]].halfedge = ...

# Line 143-145 (AFTER)
Edges[...].vertex = vertices[all_facet_edges[i][1]]  # CORRECT - destination
vertices[all_facet_edges[i][1]].halfedge = ...
```

## Evidence

1. **Documentation**: Line 290 says `vertex.halfedge` is "a halfedge that points to the vertex", but the parser sets it to a halfedge starting FROM the vertex.

2. **Library method broken**: `get_angle_normal()` computes edge direction as `he.vertex - he.prev.vertex`, assuming destination convention. With the bug, it returns wrong directions.

3. **Original source**: [carlosrojas/halfedge_mesh](https://github.com/carlosrojas/halfedge_mesh), uses `[1]` (destination).

## Impact

- One-ring traversal returns wrong faces
- Dual mesh computation fails
- `get_angle_normal()` breaks
- `he.opposite.vertex == he.prev.vertex` fails

## Test

```python
mesh = HalfedgeMesh("any.off")

# Check invariant: he.opposite.vertex == he.prev.vertex
violations = 0
for he in mesh.halfedges:
    if he.opposite and he.opposite.vertex != he.prev.vertex:
        violations += 1

print(f"Violations: {violations}")  # Should be 0, but prints >0 with bug
```
